### PR TITLE
fixed section export the certificate

### DIFF
--- a/User Guides/1-Prerequisite Steps Before Deployment.md
+++ b/User Guides/1-Prerequisite Steps Before Deployment.md
@@ -39,8 +39,8 @@ $childCert = Get-ChildItem -Path cert:\CurrentUser\My | ?{ $_.Subject -eq "CN=Co
 $type = [System.Security.Cryptography.X509Certificates.X509Certificate]::pfx
 $securePassword = ConvertTo-SecureString -String "MyPassword" -Force –AsPlainText
 
-Export-PfxCertificate -Cert $rootCert -FilePath "ContosoRootCertificate.pfx" -Password $securePassword -Verbose
-Export-PfxCertificate -Cert $childCert -FilePath "ContosoChildCertificate.pfx" -Password $securePassword -Verbose
+Export-PfxCertificate -Cert $rootCert[1] -FilePath "ContosoRootCertificate.pfx" -Password $securePassword -Verbose
+Export-PfxCertificate -Cert $childCert[1] -FilePath "ContosoChildCertificate.pfx" -Password $securePassword -Verbose
 ```
 Share these two files with the users who need VPN access, instructing them to install these files in their client machines (using Certmgr or other tools).
 


### PR DESCRIPTION
Export-PfxCertificate cmdlet is failing with this error - 
"Export-PfxCertificate : Cannot convert 'System.Object[]' to the type 'Microsoft.CertificateServices.Commands.Certificate' required by parameter 'Cert'. Specified method is not supported."

Updated the command to avoid this error.